### PR TITLE
Better log information

### DIFF
--- a/kiwi_obs_plugin/tasks/image_obs.py
+++ b/kiwi_obs_plugin/tasks/image_obs.py
@@ -90,7 +90,7 @@ class ImageObsTask(CliTask):
             self.load_xml_description(
                 obs_checkout.checkout_dir
             )
-            self.obs.add_obs_repositories(
+            repo_status = self.obs.add_obs_repositories(
                 self.xml_state, obs_checkout.profile,
                 self.command_args['--arch'] or 'x86_64',
                 self.command_args['--repo'] or 'images'
@@ -98,5 +98,6 @@ class ImageObsTask(CliTask):
             self.obs.write_kiwi_config_from_state(
                 self.xml_state, self.config_file
             )
-            log.info('OBS project checked out at:')
+            self.obs.print_repository_status(repo_status)
+            log.info('Successfully checked out OBS project at:')
             log.info(f'--> {obs_checkout.checkout_dir}')

--- a/test/unit/obs_test.py
+++ b/test/unit/obs_test.py
@@ -1,5 +1,7 @@
 import io
 import os
+import logging
+from typing import Any
 from mock import (
     patch, Mock, MagicMock, call
 )
@@ -18,7 +20,9 @@ from kiwi_obs_plugin.exceptions import (
     KiwiOBSPluginCredentialsError
 )
 
-from kiwi_obs_plugin.obs import OBS
+from kiwi_obs_plugin.obs import (
+    OBS, obs_repo_status_type
+)
 
 
 class TestOBS:
@@ -206,6 +210,22 @@ class TestOBS:
             xml_state.xml_data.export.assert_called_once_with(
                 outfile=file_handle, level=0
             )
+
+    def test_print_repository_status(self):
+        log: Any = logging.getLogger('kiwi')
+        repo_status = {
+            'repo_a': obs_repo_status_type(
+                flag='ok', message='imported'
+            ),
+            'repo_b': obs_repo_status_type(
+                flag='unreachable', message='ignored:error'
+            )
+        }
+        with self._caplog.at_level(logging.WARNING):
+            self.obs.print_repository_status(repo_status)
+        log.setLogLevel(logging.DEBUG)
+        with self._caplog.at_level(logging.DEBUG):
+            self.obs.print_repository_status(repo_status)
 
     @patch('requests.get')
     @patch('kiwi_obs_plugin.obs.HTTPBasicAuth')

--- a/test/unit/tasks/image_obs_test.py
+++ b/test/unit/tasks/image_obs_test.py
@@ -62,6 +62,9 @@ class TestImageObsTask:
         obs.add_obs_repositories.assert_called_once_with(
             self.task.xml_state, 'Kernel', 'x86_64', 'images'
         )
+        obs.print_repository_status.assert_called_once_with(
+            obs.add_obs_repositories.return_value
+        )
         obs.write_kiwi_config_from_state.assert_called_once_with(
             self.task.xml_state, '../data/appliance.kiwi'
         )


### PR DESCRIPTION
The former report about repositories was confusing. This commit
changes it in a way that by default a collective information about
the successfully imported repositories is displayed. If there are
issues an additional warning message is displayed saying that
further information is available in debug mode.